### PR TITLE
Add OpenShift deployment support for Digital Twins for Fluid Simulation blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,51 @@ All quantities displayed are averaged values.The impact of these modifications o
 There are also several predefined views you can toggle between to get different perspectives on the vehicle and its aerodynamic performance. 
 
 
+## OpenShift Deployment
+
+This blueprint can be deployed on Red Hat OpenShift AI using the included Helm
+chart with OpenShift support. The Helm chart lives in
+`deploy/helm/digital-twins-fluid-sim/` and includes:
+
+- An `openshift.enabled` feature flag (disabled by default) that gates all
+  OpenShift-specific resources — vanilla Kubernetes deployments are unaffected.
+- OpenShift Routes for the web frontend (edge TLS termination).
+- A custom SecurityContextConstraints (SCC) and RoleBinding for the Kit GPU
+  renderer and NIM inference pods.
+- NIM Operator integration (NIMCache + NIMService) for the Domino Automotive
+  Aero NIM, replacing the raw Deployment with operator-managed lifecycle.
+
+### Quick Start
+
+```bash
+# Create namespace and NGC secrets
+oc new-project digital-twins
+export NGC_API_KEY="<your-ngc-api-key>"
+oc create secret docker-registry ngc-secret \
+  --docker-server=nvcr.io --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}" -n digital-twins
+oc create secret generic ngc-api \
+  --from-literal=NGC_API_KEY="${NGC_API_KEY}" -n digital-twins
+
+# Label secrets for Helm adoption
+for s in ngc-secret ngc-api; do
+  oc label secret $s app.kubernetes.io/managed-by=Helm -n digital-twins
+  oc annotate secret $s meta.helm.sh/release-name=rtwt \
+    meta.helm.sh/release-namespace=digital-twins -n digital-twins
+done
+
+# Install with OpenShift overlay
+helm install rtwt deploy/helm/digital-twins-fluid-sim \
+  -f deploy/helm/digital-twins-fluid-sim/values.yaml \
+  -f deploy/helm/digital-twins-fluid-sim/values-openshift.yaml \
+  -n digital-twins
+```
+
+For the full deployment guide — including prerequisites, image building,
+GPU verification, configuration reference, and troubleshooting — see
+[docs/deploy-openshift.md](docs/deploy-openshift.md).
+
+
 ## Known issues
 
  - The blueprint supports at most one client connection at a time.

--- a/deploy/helm/digital-twins-fluid-sim/Chart.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: digital-twins-fluid-sim
+description: >-
+  Helm chart for the NVIDIA Omniverse Blueprint — Real-time CAE Digital Twins
+  for Fluid Simulation. Deploys the Domino Automotive Aero NIM, Omniverse Kit
+  CAE streaming application, and a React web frontend.
+type: application
+version: 0.1.0
+appVersion: "2.0.0"

--- a/deploy/helm/digital-twins-fluid-sim/templates/_helpers.tpl
+++ b/deploy/helm/digital-twins-fluid-sim/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "digital-twins-fluid-sim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars (DNS label limit).
+*/}}
+{{- define "digital-twins-fluid-sim.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "digital-twins-fluid-sim.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "digital-twins-fluid-sim.labels" -}}
+helm.sh/chart: {{ include "digital-twins-fluid-sim.chart" . }}
+{{ include "digital-twins-fluid-sim.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (shared by Deployments and Services).
+*/}}
+{{- define "digital-twins-fluid-sim.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "digital-twins-fluid-sim.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Docker-registry secret data from values.
+*/}}
+{{- define "digital-twins-fluid-sim.dockerconfigjson" -}}
+{{- $registry := .Values.imagePullSecret.registry -}}
+{{- $username := .Values.imagePullSecret.username -}}
+{{- $password := .Values.imagePullSecret.password -}}
+{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $registry (printf "%s:%s" $username $password | b64enc) | b64enc }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/aeronim-deployment.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/aeronim-deployment.yaml
@@ -1,0 +1,68 @@
+{{/*
+  Standard Kubernetes Deployment for the Domino Automotive Aero NIM.
+  Skipped when the NIM Operator manages this workload.
+*/}}
+{{- if .Values.aeronim.enabled }}
+{{- $nimOp := index .Values.nimOperator "domino-automotive-aero" }}
+{{- if not (and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nimOp.enabled true)) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-aeronim
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aeronim
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: aeronim
+  template:
+    metadata:
+      labels:
+        {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: aeronim
+    spec:
+      {{- if .Values.imagePullSecret.create }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: aeronim
+          image: "{{ .Values.aeronim.image.repository }}:{{ .Values.aeronim.image.tag }}"
+          imagePullPolicy: {{ .Values.aeronim.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: NGC_API_KEY
+              {{- if .Values.aeronim.env.NGC_API_KEY }}
+              value: {{ .Values.aeronim.env.NGC_API_KEY | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ngcApiSecret.name }}
+                  key: NGC_API_KEY
+              {{- end }}
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+          resources:
+            {{- toYaml .Values.aeronim.resources | nindent 12 }}
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.aeronim.shmSize | default "2Gi" }}
+          {{- with .Values.aeronim.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.aeronim.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/aeronim-nim.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/aeronim-nim.yaml
@@ -1,0 +1,71 @@
+{{/*
+  NIM Operator CRDs for the Domino Automotive Aero NIM.
+  Only rendered when the NIM Operator is installed on the cluster
+  AND nimOperator.domino-automotive-aero.enabled is true.
+*/}}
+{{- $nim := index .Values.nimOperator "domino-automotive-aero" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "50Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "IfNotPresent" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/aeronim-service.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/aeronim-service.yaml
@@ -1,0 +1,27 @@
+{{/*
+  Service for the Aero NIM. Created regardless of whether the NIM Operator
+  manages the pod — in the NIM Operator path, the NIMService creates its own
+  Service so this one is skipped.
+*/}}
+{{- if .Values.aeronim.enabled }}
+{{- $nimOp := index .Values.nimOperator "domino-automotive-aero" }}
+{{- if not (and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nimOp.enabled true)) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-aeronim
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aeronim
+spec:
+  type: {{ .Values.aeronim.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.aeronim.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: aeronim
+{{- end }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/coturn-deployment.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/coturn-deployment.yaml
@@ -1,0 +1,145 @@
+{{- if .Values.coturn.enabled }}
+{{- $fullName := include "digital-twins-fluid-sim.fullname" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-coturn
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-coturn-auth
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+type: Opaque
+stringData:
+  password: {{ .Values.coturn.auth.password | default "changeme" | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-coturn-config
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+data:
+  turnserver.conf: |
+    listening-port=3478
+    tls-listening-port=5349
+    min-port={{ .Values.coturn.relay.minPort | default 49200 }}
+    max-port={{ .Values.coturn.relay.maxPort | default 49300 }}
+
+    listening-ip=0.0.0.0
+    relay-ip=0.0.0.0
+
+    fingerprint
+    lt-cred-mech
+    realm={{ .Values.coturn.realm | default "turn.local" }}
+    user={{ .Values.coturn.auth.username | default "turnuser" }}:TURN_PASSWORD_PLACEHOLDER
+
+    no-multicast-peers
+    no-cli
+    no-tlsv1
+    no-tlsv1_1
+
+    cert=/etc/coturn/tls/tls.crt
+    pkey=/etc/coturn/tls/tls.key
+
+    simple-log
+    log-file=stdout
+    verbose
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-coturn
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: coturn
+  template:
+    metadata:
+      labels:
+        {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: coturn
+    spec:
+      serviceAccountName: {{ $fullName }}-coturn
+      containers:
+        - name: coturn
+          image: {{ .Values.coturn.image.repository }}:{{ .Values.coturn.image.tag }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              sed "s|TURN_PASSWORD_PLACEHOLDER|${TURN_PASSWORD}|g" \
+                /etc/coturn/config/turnserver.conf > /tmp/turnserver.conf
+              exec turnserver -c /tmp/turnserver.conf
+          ports:
+            - containerPort: 3478
+              name: turn
+              protocol: TCP
+            - containerPort: 5349
+              name: turns
+              protocol: TCP
+          env:
+            - name: TURN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.coturn.auth.existingSecret | default (printf "%s-coturn-auth" $fullName) }}
+                  key: {{ .Values.coturn.auth.secretKey | default "password" }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/coturn/config
+              readOnly: true
+            - name: tls
+              mountPath: /etc/coturn/tls
+              readOnly: true
+          resources:
+            {{- toYaml .Values.coturn.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-coturn-config
+        - name: tls
+          secret:
+            secretName: {{ .Values.coturn.tls.secretName | default (printf "%s-coturn-tls" $fullName) }}
+      {{- with .Values.coturn.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.coturn.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-coturn
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+  ports:
+    - name: turns
+      port: 5349
+      targetPort: 5349
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/kit-deployment.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/kit-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-kit
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kit
+  template:
+    metadata:
+      labels:
+        {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kit
+    spec:
+      {{- if .Values.imagePullSecret.create }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: kit
+          image: "{{ .Values.kit.image.repository }}:{{ .Values.kit.image.tag }}"
+          imagePullPolicy: {{ .Values.kit.image.pullPolicy }}
+          {{- with .Values.kit.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 49100
+              protocol: TCP
+            - name: webrtc-udp
+              containerPort: 1024
+              protocol: UDP
+            {{- range untilStep 47995 48013 1 }}
+            - name: stream-t-{{ . }}
+              containerPort: {{ . }}
+              protocol: TCP
+            {{- end }}
+            {{- range untilStep 47995 48013 1 }}
+            - name: stream-u-{{ . }}
+              containerPort: {{ . }}
+              protocol: UDP
+            {{- end }}
+            {{- range untilStep 49000 49008 1 }}
+            - name: rtc-t-{{ . }}
+              containerPort: {{ . }}
+              protocol: TCP
+            {{- end }}
+            {{- range untilStep 49000 49008 1 }}
+            - name: rtc-u-{{ . }}
+              containerPort: {{ . }}
+              protocol: UDP
+            {{- end }}
+          env:
+            - name: CUDA_VISIBLE_DEVICES
+              value: "0"
+            - name: KIT_APP
+              value: {{ .Values.kit.env.KIT_APP | quote }}
+            - name: USD_URL
+              value: {{ .Values.kit.env.USD_URL | quote }}
+            - name: STL_PATH_FORMAT
+              value: {{ .Values.kit.env.STL_PATH_FORMAT | quote }}
+            - name: NIM_TRITON_IP_ADDRESS
+              {{- $nimOp := index .Values.nimOperator "domino-automotive-aero" }}
+              {{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nimOp.enabled true) }}
+              value: {{ $nimOp.service.name | quote }}
+              {{- else }}
+              value: {{ include "digital-twins-fluid-sim.fullname" . }}-aeronim
+              {{- end }}
+            - name: NIM_TRITON_HTTP_PORT
+              value: "8080"
+            - name: SenderTimeout
+              value: {{ .Values.kit.env.SenderTimeout | quote }}
+            - name: OPENBLAS_NUM_THREADS
+              value: {{ .Values.kit.env.OPENBLAS_NUM_THREADS | quote }}
+            {{- with .Values.kit.env.OMNI_USER }}
+            - name: OMNI_USER
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.kit.env.OMNI_PASS }}
+            - name: OMNI_PASS
+              value: {{ . | quote }}
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.kit.persistence.ovCache.enabled }}
+            - name: ov-cache
+              mountPath: /home/ubuntu/.cache/ov
+            {{- end }}
+            {{- if .Values.kit.persistence.ovLocalShare.enabled }}
+            - name: ov-local-share
+              mountPath: /home/ubuntu/.local/share/ov
+            {{- end }}
+          resources:
+            {{- toYaml .Values.kit.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.kit.persistence.ovCache.enabled }}
+        - name: ov-cache
+          persistentVolumeClaim:
+            claimName: {{ include "digital-twins-fluid-sim.fullname" . }}-ov-cache
+        {{- end }}
+        {{- if .Values.kit.persistence.ovLocalShare.enabled }}
+        - name: ov-local-share
+          persistentVolumeClaim:
+            claimName: {{ include "digital-twins-fluid-sim.fullname" . }}-ov-local-share
+        {{- end }}
+      {{- with .Values.kit.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kit.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/kit-pvc.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/kit-pvc.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.kit.persistence.ovCache.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-ov-cache
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kit
+spec:
+  accessModes:
+    - {{ .Values.kit.persistence.ovCache.accessMode }}
+  {{- if .Values.kit.persistence.ovCache.storageClass }}
+  storageClassName: {{ .Values.kit.persistence.ovCache.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.kit.persistence.ovCache.size }}
+{{- end }}
+---
+{{- if .Values.kit.persistence.ovLocalShare.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-ov-local-share
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kit
+spec:
+  accessModes:
+    - {{ .Values.kit.persistence.ovLocalShare.accessMode }}
+  {{- if .Values.kit.persistence.ovLocalShare.storageClass }}
+  storageClassName: {{ .Values.kit.persistence.ovLocalShare.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.kit.persistence.ovLocalShare.size }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/kit-service.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/kit-service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-kit
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kit
+spec:
+  type: {{ .Values.kit.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.kit.service.httpPort }}
+      targetPort: 49100
+      protocol: TCP
+    - name: webrtc-udp
+      port: 1024
+      targetPort: 1024
+      protocol: UDP
+    {{- range $i, $port := untilStep 47995 48013 1 }}
+    - name: stream-tcp-{{ $port }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: TCP
+    {{- end }}
+    {{- range $i, $port := untilStep 47995 48013 1 }}
+    - name: stream-udp-{{ $port }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: UDP
+    {{- end }}
+    {{- range $i, $port := untilStep 49000 49008 1 }}
+    - name: rtc-tcp-{{ $port }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: TCP
+    {{- end }}
+    {{- range $i, $port := untilStep 49000 49008 1 }}
+    - name: rtc-udp-{{ $port }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: UDP
+    {{- end }}
+  selector:
+    {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kit

--- a/deploy/helm/digital-twins-fluid-sim/templates/openshift.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/openshift.yaml
@@ -1,0 +1,207 @@
+{{- if .Values.openshift.enabled }}
+{{- $fullName := include "digital-twins-fluid-sim.fullname" . }}
+{{- $routes := .Values.openshift.routes | default dict }}
+
+{{/*
+  Route: web frontend
+*/}}
+{{- $webRoute := $routes.web | default dict }}
+{{- if $webRoute.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-web
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  {{- with $webRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $webRoute.host }}
+  host: {{ . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}-web
+    weight: 100
+  port:
+    targetPort: http
+  {{- with $webRoute.tls }}
+  tls:
+    termination: {{ .termination | default "edge" }}
+    {{- with .insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ . }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}
+
+{{/*
+  Route: Kit signaling (WebSocket over edge TLS).
+  HAProxy terminates TLS and forwards plain HTTP/WS to Kit:49100.
+  WebRTC media goes through the coturn TURN relay, not this Route.
+*/}}
+{{- $kitRoute := $routes.kit | default dict }}
+{{- if $kitRoute.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-kit
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kit
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- with $kitRoute.host }}
+  host: {{ . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}-kit
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}
+
+{{/*
+  Route: coturn TURN-TLS relay (passthrough).
+  The browser dials turns:<hostname>:443?transport=tcp. HAProxy uses SNI
+  to route the raw TLS stream to coturn:5349, which terminates TLS and
+  relays UDP media between Kit and the browser inside the tunnel.
+*/}}
+{{- $coturnRoute := $routes.coturn | default dict }}
+{{- if and $coturnRoute.enabled $.Values.coturn.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-turn
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+  annotations:
+    haproxy.router.openshift.io/timeout: "3600s"
+spec:
+  {{- with $coturnRoute.host }}
+  host: {{ . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}-coturn
+    weight: 100
+  port:
+    targetPort: turns
+  tls:
+    termination: passthrough
+  wildcardPolicy: None
+{{- end }}
+
+{{/*
+  RoleBinding: coturn ServiceAccount → anyuid SCC.
+  coturn image runs as a non-default UID.
+*/}}
+{{- if $.Values.coturn.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-coturn-anyuid
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coturn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-coturn
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.openshift.scc.create }}
+---
+# Custom SCC for the Kit application which requires privileged access for
+# GPU/Vulkan rendering, and for NIM pods that need anyuid.  Based on
+# "nonroot" with seLinuxContext: RunAsAny to avoid recursive relabeling of
+# cached Omniverse shader/data volumes.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ $fullName }}-scc
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      SCC for the Digital Twins Fluid Simulation blueprint.  Allows privileged
+      containers (required by the Omniverse Kit GPU/Vulkan renderer) and
+      host IPC (required by the Aero NIM for CUDA IPC).
+priority: {{ .Values.openshift.scc.priority | default 10 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: true
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:default
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - system:serviceaccount:{{ $.Release.Namespace }}:{{ $nimVal.service.name }}
+  {{- end }}
+  {{- end }}
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-scc
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ $fullName }}-scc
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - kind: ServiceAccount
+    name: {{ $nimVal.service.name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/secrets.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.imagePullSecret.create .Values.imagePullSecret.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "digital-twins-fluid-sim.dockerconfigjson" . }}
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/stream-config.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/stream-config.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.coturn.enabled }}
+{{- $fullName := include "digital-twins-fluid-sim.fullname" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-stream-config
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  stream-config.json: |
+    {
+      "signalingServer": {{ .Values.streamConfig.signalingServer | default "" | quote }},
+      "signalingPort": {{ .Values.streamConfig.signalingPort | default 443 }},
+      "forceWSS": {{ .Values.streamConfig.forceWSS | default true }},
+      "turn": {
+        "urls": {{ .Values.streamConfig.turn.urls | default "" | quote }},
+        "username": {{ .Values.streamConfig.turn.username | default "" | quote }},
+        "credential": {{ .Values.streamConfig.turn.credential | default "" | quote }}
+      }
+    }
+{{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/web-configmap.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/web-configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-nginx
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  default.conf: |
+    upstream kit_http {
+      server {{ include "digital-twins-fluid-sim.fullname" . }}-kit:{{ .Values.kit.service.httpPort }};
+    }
+
+    server {
+      listen 80;
+      server_name _;
+
+      root /usr/share/nginx/html;
+      index index.html;
+
+      location / {
+        try_files $uri /index.html;
+      }
+
+      location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        expires -1;
+      }
+
+      location = /stream-config.json {
+        alias /etc/nginx/stream-config/stream-config.json;
+        default_type application/json;
+        add_header Cache-Control "no-cache, must-revalidate" always;
+      }
+
+      location /api/ {
+        proxy_pass http://kit_http/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      location /ws/ {
+        proxy_pass http://kit_http/ws/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+      }
+    }

--- a/deploy/helm/digital-twins-fluid-sim/templates/web-deployment.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/web-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-web
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            {{- if .Values.coturn.enabled }}
+            - name: stream-config
+              mountPath: /etc/nginx/stream-config
+              readOnly: true
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "digital-twins-fluid-sim.fullname" . }}-nginx
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        {{- if .Values.coturn.enabled }}
+        - name: stream-config
+          configMap:
+            name: {{ include "digital-twins-fluid-sim.fullname" . }}-stream-config
+        {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/digital-twins-fluid-sim/templates/web-service.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/templates/web-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "digital-twins-fluid-sim.fullname" . }}-web
+  labels:
+    {{- include "digital-twins-fluid-sim.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "digital-twins-fluid-sim.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/deploy/helm/digital-twins-fluid-sim/values-openshift.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/values-openshift.yaml
@@ -1,0 +1,182 @@
+# values-openshift.yaml — OpenShift overlay for the Digital Twins Fluid Sim chart.
+#
+# Usage:
+#   helm install rtwt deploy/helm/digital-twins-fluid-sim \
+#     -f deploy/helm/digital-twins-fluid-sim/values.yaml \
+#     -f deploy/helm/digital-twins-fluid-sim/values-openshift.yaml \
+#     --set imagePullSecret.password="$NGC_API_KEY" \
+#     -n digital-twins
+#
+# This overlay:
+#   - Enables OpenShift Routes (web + Kit signaling + coturn) and SCC/RoleBindings
+#   - Deploys coturn TURN-TLS relay for WebRTC media (UDP cannot traverse Routes)
+#   - Sets Kit service to ClusterIP (signaling goes through an edge Route)
+#   - Web service uses ClusterIP (Route handles external access)
+
+# ---------------------------------------------------------------------------
+# Shorten the fullname to keep Route hostnames within DNS limits.
+# ---------------------------------------------------------------------------
+fullnameOverride: "rtwt"
+
+# On OpenShift the default SA's internal registry pull secret handles image
+# pulls for Kit and Web (from the internal registry). Setting create: false
+# prevents the chart from overriding the SA's pull secrets with ngc-secret
+# (which only covers nvcr.io).
+imagePullSecret:
+  create: false
+
+# ---------------------------------------------------------------------------
+# coturn TURN-TLS relay — solves the WebRTC UDP ingress problem.
+# The browser opens a TLS connection to coturn through a passthrough Route.
+# coturn relays UDP media between the browser and Kit inside the cluster.
+# ---------------------------------------------------------------------------
+coturn:
+  enabled: true
+  tls:
+    # TLS secret with tls.crt + tls.key matching the coturn Route hostname
+    # (e.g. rtwt-turn-digital-twins.apps.<cluster>). Create before install:
+    #   oc create secret tls rtwt-coturn-tls \
+    #     --cert=tls.crt --key=tls.key -n digital-twins
+    secretName: "rtwt-coturn-tls"
+  auth:
+    username: "turnuser"
+    password: ""      # Set via --set coturn.auth.password=<password>
+
+# Stream config tells the web frontend how to reach Kit signaling and the
+# TURN relay. Values are served as /stream-config.json by Nginx.
+# Set these AFTER install once the Route hostnames are known:
+#   helm upgrade rtwt ... \
+#     --set streamConfig.signalingServer=rtwt-kit-digital-twins.apps.<cluster> \
+#     --set streamConfig.turn.urls=turns:rtwt-turn-digital-twins.apps.<cluster>:443?transport=tcp \
+#     --set streamConfig.turn.username=turnuser \
+#     --set streamConfig.turn.credential=<password>
+streamConfig:
+  signalingServer: ""
+  signalingPort: 443
+  forceWSS: true
+  turn:
+    urls: ""
+    username: "turnuser"
+    credential: ""
+
+# ---------------------------------------------------------------------------
+# OpenShift features
+# ---------------------------------------------------------------------------
+openshift:
+  enabled: true
+
+  routes:
+    web:
+      enabled: true
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    kit:
+      enabled: true
+    coturn:
+      enabled: true
+
+  scc:
+    create: true
+
+# ---------------------------------------------------------------------------
+# Override web service to ClusterIP — the Route handles external access.
+# ---------------------------------------------------------------------------
+web:
+  image:
+    repository: image-registry.openshift-image-registry.svc:5000/digital-twins/rtdt-web-app
+    tag: "latest"
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+
+# ---------------------------------------------------------------------------
+# Kit configuration for OpenShift.
+# Service type is ClusterIP — signaling is exposed via an edge Route.
+# WebRTC media goes through the coturn TURN relay.
+# ---------------------------------------------------------------------------
+kit:
+  image:
+    repository: image-registry.openshift-image-registry.svc:5000/digital-twins/rtdt-kit-app
+    tag: "latest"
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+  tolerations:
+    - key: g6-gpu
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+  persistence:
+    ovCache:
+      enabled: true
+      size: 50Gi
+      storageClass: "gp3-csi"
+      accessMode: ReadWriteOnce
+    ovLocalShare:
+      enabled: true
+      size: 10Gi
+      storageClass: "gp3-csi"
+      accessMode: ReadWriteOnce
+
+# ---------------------------------------------------------------------------
+# Use a standard Deployment for the Aero NIM.
+# The Domino Automotive Aero NIM has an internal port conflict when managed
+# by the NIM Operator (TRITON_HTTP_PORT 8080 conflicts with its API server).
+# ---------------------------------------------------------------------------
+aeronim:
+  enabled: true
+  tolerations:
+    - key: g6-gpu
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration for the Domino Automotive Aero NIM.
+# Requires: NIM Operator installed, NGC image-pull and API secrets in namespace.
+# ---------------------------------------------------------------------------
+nimOperator:
+  domino-automotive-aero:
+    enabled: false
+    replicas: 1
+    service:
+      name: "aeronim"
+    image:
+      repository: nvcr.io/nim/nvidia/domino-automotive-aero
+      tag: "2.0.0"
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    storage:
+      pvc:
+        create: true
+        size: "50Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: "gp3-csi"
+    nodeSelector: {}
+    tolerations:
+      - key: g6-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+    env:
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8080
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8080
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 180

--- a/deploy/helm/digital-twins-fluid-sim/values.yaml
+++ b/deploy/helm/digital-twins-fluid-sim/values.yaml
@@ -1,0 +1,225 @@
+# Default values for digital-twins-fluid-sim.
+# This chart deploys three components:
+#   1. aeronim  — Domino Automotive Aero NIM (AI inference)
+#   2. kit      — Omniverse Kit CAE streaming application
+#   3. web      — React frontend served by Nginx
+
+nameOverride: ""
+fullnameOverride: ""
+
+# ---------------------------------------------------------------------------
+# NGC image-pull secret
+# ---------------------------------------------------------------------------
+imagePullSecret:
+  name: "ngc-secret"
+  registry: "nvcr.io"
+  username: "$oauthtoken"
+  # Set via --set imagePullSecret.password=$NGC_API_KEY at install time.
+  password: ""
+  create: true
+
+# NGC API secret used by the NIM Operator for model downloads.
+ngcApiSecret:
+  name: "ngc-api"
+
+# ---------------------------------------------------------------------------
+# Aero NIM — Domino Automotive Aerodynamics inference service
+# ---------------------------------------------------------------------------
+aeronim:
+  enabled: true
+  image:
+    repository: nvcr.io/nim/nvidia/domino-automotive-aero
+    tag: "2.0.0"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+    requests:
+      nvidia.com/gpu: 1
+  env:
+    NGC_API_KEY: ""
+  shmSize: "2Gi"
+  nodeSelector: {}
+  tolerations: []
+
+# ---------------------------------------------------------------------------
+# Omniverse Kit — CAE streaming application
+# ---------------------------------------------------------------------------
+kit:
+  image:
+    repository: rtdt-kit-app
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    # NodePort is required for WebRTC streaming (UDP ports cannot use Routes
+    # or Ingress). Use ClusterIP only if clients connect from inside the
+    # cluster or through a LoadBalancer that supports UDP.
+    type: NodePort
+    httpPort: 49100
+  env:
+    KIT_APP: "omni.rtwt.webrtc.kit"
+    USD_URL: "/home/ubuntu/usd/world_rtwt_minimal.usda"
+    STL_PATH_FORMAT: "/data/low_res/detailed_car_{}/aero_suv_low.stl"
+    OMNI_USER: ""
+    OMNI_PASS: ""
+    SenderTimeout: "100000"
+    OPENBLAS_NUM_THREADS: "10"
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+    requests:
+      nvidia.com/gpu: 1
+  # Kit requires elevated privileges for GPU/Vulkan access.
+  securityContext:
+    privileged: true
+  persistence:
+    ovCache:
+      enabled: true
+      size: 50Gi
+      storageClass: ""
+      accessMode: ReadWriteOnce
+    ovLocalShare:
+      enabled: true
+      size: 10Gi
+      storageClass: ""
+      accessMode: ReadWriteOnce
+  nodeSelector: {}
+  tolerations: []
+
+# ---------------------------------------------------------------------------
+# Web frontend — React app served by Nginx
+# ---------------------------------------------------------------------------
+web:
+  image:
+    repository: rtdt-web-app
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    type: ClusterIP
+    port: 80
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+
+# ---------------------------------------------------------------------------
+# TURN relay (coturn) — bridges WebRTC UDP media through TLS for environments
+# where direct UDP ingress is unavailable (e.g. OpenShift Routes).
+# Disabled by default. Enable alongside the coturn Route in values-openshift.yaml.
+# ---------------------------------------------------------------------------
+coturn:
+  enabled: false
+  image:
+    repository: quay.io/coturn/coturn
+    tag: "4.7.0"
+  auth:
+    username: "turnuser"
+    password: "changeme"
+    # Use an existing secret instead of the chart-managed one:
+    # existingSecret: "my-coturn-secret"
+    # secretKey: "password"
+  tls:
+    # TLS secret with tls.crt + tls.key matching the coturn Route hostname.
+    # Must be created before install (e.g. via cert-manager Certificate CR).
+    secretName: ""
+  realm: "turn.local"
+  relay:
+    minPort: 49200
+    maxPort: 49300
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1
+      memory: 512Mi
+  nodeSelector: {}
+  tolerations: []
+
+# ---------------------------------------------------------------------------
+# Stream config — passed to the web frontend so it knows how to reach the
+# Kit signaling server and (optionally) the TURN relay. Only used when
+# coturn.enabled=true. Values are written into a JSON file served by Nginx
+# at /stream-config.json; the React app fetches it at startup.
+# ---------------------------------------------------------------------------
+streamConfig:
+  signalingServer: ""
+  signalingPort: 443
+  forceWSS: true
+  turn:
+    urls: ""
+    username: ""
+    credential: ""
+
+# ---------------------------------------------------------------------------
+# OpenShift support (disabled by default — zero impact on vanilla Kubernetes)
+# ---------------------------------------------------------------------------
+openshift:
+  enabled: false
+
+  routes:
+    web:
+      enabled: false
+      host: ""
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    # Kit signaling route (edge TLS → Kit:49100 WebSocket).
+    kit:
+      enabled: false
+      host: ""
+    # coturn TURN-TLS route (passthrough → coturn:5349).
+    coturn:
+      enabled: false
+      host: ""
+
+  scc:
+    create: false
+    priority: 10
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration (disabled by default).
+# When enabled AND the NIM Operator CRD is present on the cluster, a NIMCache +
+# NIMService pair is created for the Aero NIM instead of a raw Deployment.
+# ---------------------------------------------------------------------------
+nimOperator:
+  domino-automotive-aero:
+    enabled: false
+    replicas: 1
+    service:
+      name: "aeronim"
+    image:
+      repository: nvcr.io/nim/nvidia/domino-automotive-aero
+      tag: "2.0.0"
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    storage:
+      pvc:
+        create: true
+        size: "50Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    nodeSelector: {}
+    tolerations: []
+    env: []
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8080
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8080
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 180

--- a/docs/deploy-openshift.md
+++ b/docs/deploy-openshift.md
@@ -1,0 +1,487 @@
+# Deploying the Real-Time Wind Tunnel Digital Twin on Red Hat OpenShift AI
+
+## What We're Deploying
+
+The NVIDIA Omniverse Blueprint for Real-Time CAE Digital Twins combines an AI
+surrogate model, a GPU-accelerated 3D renderer, and a web frontend into an
+interactive wind tunnel for vehicle aerodynamics.
+
+| Namespace | Component | Image | GPU | Port | Purpose |
+|-----------|-----------|-------|-----|------|---------|
+| digital-twins | Aero NIM | `nvcr.io/nim/nvidia/domino-automotive-aero:2.0.0` | 1 | 8080 | DoMINO aerodynamic inference |
+| digital-twins | Kit (Omniverse) | `rtdt-kit-app:latest` | 1 | 49100 (HTTP), 47995–48012, 49000–49007 (WebRTC) | USD scene rendering + WebRTC streaming |
+| digital-twins | Web | `rtdt-web-app:latest` | 0 | 80 | React UI + Nginx reverse proxy to Kit |
+
+**Data flow:** Browser &rarr; Web (React UI) &rarr; Kit (WebRTC stream + API proxy)
+&rarr; Aero NIM (inference) &rarr; Kit (renders results) &rarr; Browser (live 3D viewport)
+
+**Total resources:** 3 pods, 2 GPUs, ~110 GB storage (PVCs for Omniverse caches
+and NIM model).
+
+### NIM Operator Components
+
+When deployed with the NIM Operator (recommended on OpenShift), the Aero NIM is
+managed as a pair of custom resources:
+
+- **NIMCache** &mdash; downloads and caches the DoMINO model on a PVC. Annotated
+  with `helm.sh/resource-policy: keep` to survive upgrades and uninstalls.
+- **NIMService** &mdash; runs the inference server, references its NIMCache for
+  model storage, manages replicas, GPU allocation, and health probes.
+
+### WebRTC Streaming Architecture
+
+This blueprint uses Omniverse Kit App Streaming with WebRTC. The web frontend
+proxies HTTP API and WebSocket traffic to Kit via Nginx (`/api/`, `/ws/`), but
+the actual video stream uses direct UDP connections on ports 47995–48012 and
+49000–49007. **OpenShift Routes cannot handle UDP traffic**, so the Kit service
+must remain as NodePort (or LoadBalancer) even when OpenShift Routes are used
+for the web frontend.
+
+## Tested Hardware
+
+| Parameter | Value |
+|-----------|-------|
+| Platform | Red Hat OpenShift AI (RHOAI) 4.14+ |
+| GPU nodes | 1+ nodes with NVIDIA RTX GPUs (L40/L40s, A6000, or RTX 6000 Pro) |
+| GPUs per node | 2+ (one for Kit, one for Aero NIM) |
+| Total GPUs | 2 |
+| VRAM | 40 GB+ per GPU |
+| CPU | 32+ cores |
+| RAM | 128 GB+ |
+| Storage | 100 GB+ (dynamic provisioning recommended) |
+| API keys | NVIDIA NGC API key |
+
+**Minimum for reproduction:** 2 &times; NVIDIA L40s / A6000 GPUs with 40 GB+
+VRAM each, 128 GB RAM, 100 GB storage.
+
+## What's Different from Upstream
+
+| Area | Upstream Default | OpenShift Deployment | Impact |
+|------|-----------------|---------------------|--------|
+| Orchestration | Docker Compose | Helm chart on Kubernetes | Declarative lifecycle management |
+| Aero NIM management | Docker container with `runtime: nvidia` | NIM Operator (NIMCache + NIMService) | Automated model download, cache lifecycle |
+| External access (web) | Host port mapping | OpenShift Route with TLS | Production-grade HTTPS ingress |
+| External access (Kit streaming) | Host port mapping | NodePort Service | WebRTC UDP requires direct connectivity |
+| Security context | `privileged: true` in Compose | Custom SCC with privileged + host IPC | Compatible with OpenShift SCC enforcement |
+| Volume management | Docker named volumes | Dynamic PVCs | Cluster-native storage provisioning |
+| Kit image | Built locally via `build-docker.sh` | Pre-built and pushed to registry | Must push to accessible registry before deploy |
+
+## Prerequisites
+
+### CLI Tools
+
+- `oc` (OpenShift CLI) v4.14+
+- `helm` v3.12+
+- `docker` (for building and pushing images)
+
+### Cluster Requirements
+
+- OpenShift 4.14+ with NVIDIA GPU Operator installed
+- NIM Operator installed (provides `apps.nvidia.com/v1alpha1` API)
+- At least 2 available GPUs on the same or different nodes
+
+### Build and Push Images
+
+The Kit and Web images must be built and pushed to a registry accessible from
+your OpenShift cluster. The Aero NIM image is pulled directly from `nvcr.io`.
+
+```bash
+# Build images locally
+./build-docker.sh
+
+# Tag and push to your registry
+export REGISTRY=your-registry.example.com/digital-twins
+docker tag rtdt-kit-app:latest ${REGISTRY}/rtdt-kit-app:latest
+docker tag rtdt-web-app:latest ${REGISTRY}/rtdt-web-app:latest
+docker push ${REGISTRY}/rtdt-kit-app:latest
+docker push ${REGISTRY}/rtdt-web-app:latest
+```
+
+Update `values-openshift.yaml` to reference your registry:
+
+```yaml
+kit:
+  image:
+    repository: your-registry.example.com/digital-twins/rtdt-kit-app
+web:
+  image:
+    repository: your-registry.example.com/digital-twins/rtdt-web-app
+```
+
+### Verify GPU Availability
+
+```bash
+oc get nodes -l nvidia.com/gpu.present=true -o custom-columns=\
+NAME:.metadata.name,\
+GPUS:.status.capacity.nvidia\.com/gpu,\
+ALLOCATABLE:.status.allocatable.nvidia\.com/gpu
+```
+
+### Resource Requirements
+
+| Resource | Aero NIM | Kit | Web | Total |
+|----------|----------|-----|-----|-------|
+| GPU | 1 | 1 | 0 | 2 |
+| Model storage | ~50 Gi | — | — | ~50 Gi |
+| Cache storage | — | 50 Gi (ov-cache) + 10 Gi (ov-local-share) | — | ~60 Gi |
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NGC_API_KEY` | Yes | — | NGC API key for pulling NIM images and model downloads |
+
+### OpenShift Block (`openshift:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `openshift.enabled` | `false` | Master toggle for all OpenShift resources |
+| `openshift.routes.web.enabled` | `false` | Create a Route for the web frontend |
+| `openshift.routes.web.host` | `""` | Hostname (auto-generated if empty) |
+| `openshift.routes.web.tls.termination` | `edge` | TLS termination strategy |
+| `openshift.scc.create` | `false` | Create custom SCC and RoleBinding |
+| `openshift.scc.priority` | `10` | SCC priority |
+
+### NIM Operator Block (`nimOperator:`)
+
+The Aero NIM (`nimOperator.domino-automotive-aero`) supports:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Deploy via NIM Operator instead of raw Deployment |
+| `replicas` | `1` | Number of inference replicas |
+| `image.repository` | `nvcr.io/nim/nvidia/domino-automotive-aero` | NGC container image |
+| `image.tag` | `2.0.0` | Image version |
+| `resources.limits.nvidia.com/gpu` | `1` | GPU allocation |
+| `storage.pvc.size` | `50Gi` | Model cache PVC size |
+| `storage.pvc.storageClass` | `""` | StorageClass (cluster default if empty) |
+| `expose.service.port` | `8080` | Service port |
+
+## Deployment
+
+### 1. Create Namespace
+
+```bash
+oc new-project digital-twins
+```
+
+### 2. Create NGC Secrets
+
+The NGC registry secret must carry Helm ownership labels so `helm install` can
+adopt it:
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+
+oc create secret docker-registry ngc-secret \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}" \
+  -n digital-twins
+
+oc label secret ngc-secret \
+  app.kubernetes.io/managed-by=Helm -n digital-twins
+oc annotate secret ngc-secret \
+  meta.helm.sh/release-name=rtwt \
+  meta.helm.sh/release-namespace=digital-twins -n digital-twins
+```
+
+Create the NGC API secret for the NIM Operator:
+
+```bash
+oc create secret generic ngc-api \
+  --from-literal=NGC_API_KEY="${NGC_API_KEY}" \
+  -n digital-twins
+
+oc label secret ngc-api \
+  app.kubernetes.io/managed-by=Helm -n digital-twins
+oc annotate secret ngc-api \
+  meta.helm.sh/release-name=rtwt \
+  meta.helm.sh/release-namespace=digital-twins -n digital-twins
+```
+
+### 3. Install the Chart
+
+```bash
+cd deploy/helm/digital-twins-fluid-sim/
+
+helm install rtwt . \
+  -f values.yaml \
+  -f values-openshift.yaml \
+  -n digital-twins
+```
+
+This creates:
+- 1 NIMCache resource (triggers Aero NIM model download)
+- 1 NIMService resource (runs Aero NIM inference after cache is ready)
+- 1 Kit Deployment (Omniverse streaming with GPU)
+- 1 Web Deployment (Nginx + React frontend)
+- 1 OpenShift Route (web frontend with edge TLS)
+- 1 Custom SCC + RoleBinding (privileged access for Kit and NIM)
+- 2 PVCs (Omniverse cache and local-share)
+- 1 ConfigMap (Nginx config with Kit service discovery)
+
+### 4. Monitor NIM Model Download
+
+The NIMCache downloads the DoMINO model from NGC. This can take 10–30 minutes
+depending on network speed.
+
+```bash
+oc get nimcache -n digital-twins -w
+```
+
+Wait until the cache shows `Ready`:
+
+```
+NAME             STATUS   AGE
+aeronim-cache    Ready    15m
+```
+
+## Verification
+
+### Check All Pods
+
+```bash
+oc get pods -n digital-twins
+```
+
+Expected pods:
+
+```
+NAME                           READY   STATUS    RESTARTS   AGE
+aeronim-0                      1/1     Running   0          5m
+rtwt-kit-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
+rtwt-web-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
+```
+
+### Check NIMService Status
+
+```bash
+oc get nimservice -n digital-twins
+```
+
+### Health Checks
+
+```bash
+# Aero NIM health
+oc exec deploy/rtwt-kit -n digital-twins -- \
+  curl -s http://aeronim:8080/v1/health/ready
+
+# Web frontend
+oc exec deploy/rtwt-web -n digital-twins -- \
+  curl -s http://localhost/
+```
+
+## Accessing the UI
+
+### Web Frontend (via Route)
+
+```bash
+oc get route rtwt-web -n digital-twins -o jsonpath='{.spec.host}'
+```
+
+Open `https://<route-hostname>` in your browser. The React UI loads and
+establishes a WebRTC connection to the Kit streaming service.
+
+### Kit WebRTC Streaming (via NodePort)
+
+The Kit service exposes WebRTC streaming ports as NodePorts. Determine the node
+IP and allocated ports:
+
+```bash
+# Get the node where Kit is running
+oc get pod -l app.kubernetes.io/component=kit -n digital-twins \
+  -o jsonpath='{.items[0].status.hostIP}'
+
+# Get the allocated NodePorts
+oc get svc rtwt-kit -n digital-twins
+```
+
+The web frontend must be configured to connect to the Kit streaming endpoint.
+If the WebRTC connection does not establish, verify that:
+1. The Kit NodePort ports are reachable from the client browser
+2. Firewall rules allow UDP traffic on the allocated NodePorts
+3. The Kit pod has GPU access and started successfully
+
+## Testing End-to-End
+
+Pods being `Running` does not mean the pipeline works. Validate the full flow:
+
+1. **Open the web UI** via the Route URL
+2. **Wait for the 3D scene to load** — first launch compiles shaders (can take
+   up to 30 minutes; subsequent launches are ~2 minutes)
+3. **Modify a vehicle parameter** (e.g., toggle the spoiler)
+4. **Verify inference results update** — the aerodynamic visualization should
+   change in real-time
+5. **Test different visualization modes** — Curve Trace, Volume Trace, Slice Planes
+
+If the scene loads but inference does not work, check the Aero NIM pod logs:
+
+```bash
+oc logs -f deploy/aeronim -n digital-twins
+```
+
+## OpenShift-Specific Challenges and Solutions
+
+### 1. Kit Requires Privileged Container Access
+
+**What happened:** The Omniverse Kit application requires `privileged: true`
+for GPU/Vulkan rendering. It needs access to the NVIDIA GPU driver, Vulkan ICD
+loader, and host GPU devices. OpenShift's default `restricted` SCC blocks
+privileged containers.
+
+**Error:** Pod fails to start; Kit startup script reports
+`Fatal Error: Can't find libGLX_nvidia.so.0...`
+
+**Services affected:** Kit
+
+**Fix:** The `openshift.yaml` template creates a custom SCC
+(`<release>-scc`) that allows privileged containers, host IPC, and host
+ports. A RoleBinding grants this SCC to the `default` ServiceAccount.
+
+### 2. Aero NIM Requires Host IPC
+
+**What happened:** The upstream Docker Compose runs the Aero NIM with
+`ipc: host` for CUDA inter-process communication. The default OpenShift
+`restricted` SCC blocks host IPC access.
+
+**Services affected:** Aero NIM (Deployment path)
+
+**Fix:** The custom SCC includes `allowHostIPC: true`. When using the NIM
+Operator path, the NIMService handles IPC requirements directly.
+
+### 3. WebRTC Streaming Cannot Use OpenShift Routes
+
+**What happened:** OpenShift Routes only handle HTTP(S) traffic. Omniverse Kit
+App Streaming uses WebRTC which requires direct UDP connectivity on ports
+47995–48012 and 49000–49007 for the media stream.
+
+**Services affected:** Kit (WebRTC streaming to browser)
+
+**Fix:** The Kit service uses `type: NodePort` instead of ClusterIP. The web
+frontend Route handles the HTML/API/WebSocket traffic, while the browser
+connects directly to Kit's NodePorts for the WebRTC media stream. Ensure
+firewall rules allow UDP traffic on the allocated NodePort range.
+
+### 4. GPU Scheduling and Tolerations
+
+**What happened:** GPU nodes in OpenShift clusters often carry taints
+(`nvidia.com/gpu=present:NoSchedule`) to prevent non-GPU workloads from
+scheduling there.
+
+**Services affected:** Kit, Aero NIM
+
+**Fix:** Add tolerations in the values overlay:
+
+```yaml
+kit:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+
+nimOperator:
+  domino-automotive-aero:
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+```
+
+### 5. Kit and Web Images Must Be Pre-Built
+
+**What happened:** Unlike the other NIM-only blueprints where all images come
+from NGC, this blueprint has two custom images (`rtdt-kit-app`, `rtdt-web-app`)
+that must be built from the repo's Dockerfiles and pushed to a registry
+accessible from the OpenShift cluster.
+
+**Services affected:** Kit, Web
+
+**Fix:** Build images locally with `./build-docker.sh`, then tag and push to
+your container registry. Update the `kit.image.repository` and
+`web.image.repository` values to point to your registry.
+
+### 6. Nginx Upstream Must Match Kit Service Name
+
+**What happened:** The original `nginx.conf` hardcodes `server kit:49100` as
+the upstream. In Kubernetes, the Kit service name includes the Helm release
+prefix (e.g., `rtwt-kit`).
+
+**Services affected:** Web (Nginx proxy to Kit)
+
+**Fix:** The Helm chart templates the nginx config via a ConfigMap
+(`web-configmap.yaml`) that dynamically resolves the Kit service name using
+`{{ include "digital-twins-fluid-sim.fullname" . }}-kit`. This is mounted
+into the Nginx container, replacing the hardcoded upstream.
+
+### 7. NGC Secret Ownership by Helm
+
+**What happened:** If NGC secrets are created with `oc create secret` before
+`helm install`, Helm refuses to adopt them during install or upgrade.
+
+**Error:** `Error: rendered manifests contain a resource that already exists`
+
+**Services affected:** All (secrets are shared)
+
+**Fix:** Pre-label secrets with Helm ownership metadata before install:
+
+```bash
+oc label secret <name> app.kubernetes.io/managed-by=Helm
+oc annotate secret <name> \
+  meta.helm.sh/release-name=rtwt \
+  meta.helm.sh/release-namespace=digital-twins
+```
+
+### 8. Initial Shader Compilation Takes Up to 30 Minutes
+
+**What happened:** On the very first launch, Omniverse Kit compiles shaders
+for the scene. This is a one-time operation — compiled shaders are cached in
+the `ov-cache` PVC. However, during this time the UI shows a blank grey/black
+screen and users may think the deployment failed.
+
+**Services affected:** Kit
+
+**Fix:** Document the expected wait time. Monitor Kit logs with
+`oc logs -f deploy/rtwt-kit` to track shader compilation progress. Ensure
+the `ov-cache` PVC persists across pod restarts to avoid re-compilation.
+
+### 9. TOKENIZERS_PARALLELISM Race Condition
+
+**What happened:** NIM containers using HuggingFace tokenizers may hit a thread
+pool race condition, causing startup failures.
+
+**Services affected:** Aero NIM
+
+**Fix:** Set `TOKENIZERS_PARALLELISM=false` in the NIM Operator env config.
+The `values-openshift.yaml` overlay includes this preventively.
+
+## Cleanup
+
+Remove the Helm release:
+
+```bash
+helm uninstall rtwt -n digital-twins
+```
+
+**Important:** NIMCache PVCs persist after uninstall due to
+`helm.sh/resource-policy: keep`. This is intentional — model downloads are
+expensive. To remove them manually:
+
+```bash
+oc delete nimcache --all -n digital-twins
+oc delete pvc -l app.kubernetes.io/managed-by=nim-operator -n digital-twins
+```
+
+Remove the Omniverse cache PVCs:
+
+```bash
+oc delete pvc rtwt-ov-cache rtwt-ov-local-share -n digital-twins
+```
+
+Delete the namespace (removes all remaining resources):
+
+```bash
+oc delete project digital-twins
+```

--- a/docs/deploy-openshift.md
+++ b/docs/deploy-openshift.md
@@ -11,31 +11,39 @@ interactive wind tunnel for vehicle aerodynamics.
 | digital-twins | Aero NIM | `nvcr.io/nim/nvidia/domino-automotive-aero:2.0.0` | 1 | 8080 | DoMINO aerodynamic inference |
 | digital-twins | Kit (Omniverse) | `rtdt-kit-app:latest` | 1 | 49100 (HTTP), 47995–48012, 49000–49007 (WebRTC) | USD scene rendering + WebRTC streaming |
 | digital-twins | Web | `rtdt-web-app:latest` | 0 | 80 | React UI + Nginx reverse proxy to Kit |
+| digital-twins | coturn | `quay.io/coturn/coturn:4.7.0` | 0 | 5349 (TURNS) | TURN relay for WebRTC UDP-over-TCP tunneling |
 
 **Data flow:** Browser &rarr; Web (React UI) &rarr; Kit (WebRTC stream + API proxy)
-&rarr; Aero NIM (inference) &rarr; Kit (renders results) &rarr; Browser (live 3D viewport)
+&rarr; Aero NIM (inference) &rarr; Kit (renders results) &rarr; Browser (live 3D viewport).
+WebRTC media is tunneled through coturn (TURN relay over TLS/TCP).
 
-**Total resources:** 3 pods, 2 GPUs, ~110 GB storage (PVCs for Omniverse caches
+**Total resources:** 4 pods, 2 GPUs, ~110 GB storage (PVCs for Omniverse caches
 and NIM model).
 
-### NIM Operator Components
+### NIM Operator Components (Optional)
 
-When deployed with the NIM Operator (recommended on OpenShift), the Aero NIM is
-managed as a pair of custom resources:
-
-- **NIMCache** &mdash; downloads and caches the DoMINO model on a PVC. Annotated
-  with `helm.sh/resource-policy: keep` to survive upgrades and uninstalls.
-- **NIMService** &mdash; runs the inference server, references its NIMCache for
-  model storage, manages replicas, GPU allocation, and health probes.
+The Aero NIM can optionally be managed by the NIM Operator as a NIMCache +
+NIMService pair. However, the DoMINO Automotive Aero NIM has an internal port
+conflict when managed by the NIM Operator (`TRITON_HTTP_PORT 8080` conflicts
+with its API server), so the default OpenShift overlay uses a standard
+Deployment instead (`aeronim.enabled: true`, `nimOperator.domino-automotive-aero.enabled: false`).
 
 ### WebRTC Streaming Architecture
 
 This blueprint uses Omniverse Kit App Streaming with WebRTC. The web frontend
 proxies HTTP API and WebSocket traffic to Kit via Nginx (`/api/`, `/ws/`), but
-the actual video stream uses direct UDP connections on ports 47995–48012 and
-49000–49007. **OpenShift Routes cannot handle UDP traffic**, so the Kit service
-must remain as NodePort (or LoadBalancer) even when OpenShift Routes are used
-for the web frontend.
+the actual video stream uses UDP connections on ports 47995-48012 and
+49000-49007. **OpenShift Routes cannot handle UDP traffic** (Layer 7, TCP only),
+so the deployment includes a **coturn TURN relay** that tunnels WebRTC UDP
+media over TLS/TCP:
+
+1. **Signaling** (WebSocket): Browser &rarr; Kit edge Route (port 443) &rarr; Kit pod (port 49100)
+2. **Media** (WebRTC/UDP tunneled over TCP): Browser &rarr; coturn passthrough Route (port 443) &rarr; coturn pod (port 5349, TLS termination) &rarr; Kit pod (UDP internally)
+
+The client-side code monkey-patches `RTCPeerConnection` to inject the TURN
+server and force `iceTransportPolicy: "relay"`, ensuring all media goes through
+the tunnel. This is only activated when a TURN config is present (non-OpenShift
+deployments are unaffected).
 
 ## Tested Hardware
 
@@ -59,9 +67,9 @@ VRAM each, 128 GB RAM, 100 GB storage.
 | Area | Upstream Default | OpenShift Deployment | Impact |
 |------|-----------------|---------------------|--------|
 | Orchestration | Docker Compose | Helm chart on Kubernetes | Declarative lifecycle management |
-| Aero NIM management | Docker container with `runtime: nvidia` | NIM Operator (NIMCache + NIMService) | Automated model download, cache lifecycle |
+| Aero NIM management | Docker container with `runtime: nvidia` | Kubernetes Deployment (NIM Operator optional) | Standard Deployment with GPU resources and /dev/shm |
 | External access (web) | Host port mapping | OpenShift Route with TLS | Production-grade HTTPS ingress |
-| External access (Kit streaming) | Host port mapping | NodePort Service | WebRTC UDP requires direct connectivity |
+| External access (Kit streaming) | Host port mapping | ClusterIP + coturn TURN relay | WebRTC UDP tunneled over TLS/TCP via coturn; Kit signaling exposed through edge Route |
 | Security context | `privileged: true` in Compose | Custom SCC with privileged + host IPC | Compatible with OpenShift SCC enforcement |
 | Volume management | Docker named volumes | Dynamic PVCs | Cluster-native storage provisioning |
 | Kit image | Built locally via `build-docker.sh` | Pre-built and pushed to registry | Must push to accessible registry before deploy |
@@ -77,7 +85,8 @@ VRAM each, 128 GB RAM, 100 GB storage.
 ### Cluster Requirements
 
 - OpenShift 4.14+ with NVIDIA GPU Operator installed
-- NIM Operator installed (provides `apps.nvidia.com/v1alpha1` API)
+- cert-manager operator (for coturn TLS certificate provisioning)
+- NIM Operator (optional, for NIMCache/NIMService management of the Aero NIM)
 - At least 2 available GPUs on the same or different nodes
 
 ### Build and Push Images
@@ -141,8 +150,31 @@ ALLOCATABLE:.status.allocatable.nvidia\.com/gpu
 | `openshift.routes.web.enabled` | `false` | Create a Route for the web frontend |
 | `openshift.routes.web.host` | `""` | Hostname (auto-generated if empty) |
 | `openshift.routes.web.tls.termination` | `edge` | TLS termination strategy |
+| `openshift.routes.kit.enabled` | `false` | Create an edge Route for Kit WebSocket signaling |
+| `openshift.routes.coturn.enabled` | `false` | Create a passthrough Route for coturn TURN relay |
 | `openshift.scc.create` | `false` | Create custom SCC and RoleBinding |
 | `openshift.scc.priority` | `10` | SCC priority |
+
+### coturn Block (`coturn:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `coturn.enabled` | `false` | Deploy the coturn TURN relay |
+| `coturn.auth.username` | `turnuser` | TURN authentication username |
+| `coturn.auth.password` | `changeme` | TURN authentication password (set via `--set`) |
+| `coturn.tls.secretName` | `""` | TLS secret name for coturn (must pre-exist) |
+| `coturn.realm` | `turn.local` | TURN realm |
+
+### Stream Config Block (`streamConfig:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `streamConfig.signalingServer` | `""` | Kit Route hostname for WebSocket signaling |
+| `streamConfig.signalingPort` | `443` | Signaling port (443 via Route) |
+| `streamConfig.forceWSS` | `true` | Force secure WebSocket |
+| `streamConfig.turn.urls` | `""` | TURN server URL (e.g. `turns:hostname:443?transport=tcp`) |
+| `streamConfig.turn.username` | `""` | TURN username |
+| `streamConfig.turn.credential` | `""` | TURN credential |
 
 ### NIM Operator Block (`nimOperator:`)
 
@@ -202,7 +234,37 @@ oc annotate secret ngc-api \
   meta.helm.sh/release-namespace=digital-twins -n digital-twins
 ```
 
-### 3. Install the Chart
+### 3. Create coturn TLS Certificate
+
+The coturn TURN relay needs a TLS certificate matching its Route hostname.
+Use cert-manager (if installed) or create the secret manually:
+
+**Option A: cert-manager (recommended)**
+
+```bash
+cat <<EOF | oc apply -n digital-twins -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rtwt-coturn-tls
+spec:
+  secretName: rtwt-coturn-tls
+  issuerRef:
+    name: letsencrypt-production   # adjust to your ClusterIssuer
+    kind: ClusterIssuer
+  dnsNames:
+    - rtwt-turn-digital-twins.apps.<cluster-domain>
+EOF
+```
+
+**Option B: Manual**
+
+```bash
+oc create secret tls rtwt-coturn-tls \
+  --cert=tls.crt --key=tls.key -n digital-twins
+```
+
+### 4. Install the Chart
 
 ```bash
 cd deploy/helm/digital-twins-fluid-sim/
@@ -210,34 +272,58 @@ cd deploy/helm/digital-twins-fluid-sim/
 helm install rtwt . \
   -f values.yaml \
   -f values-openshift.yaml \
+  --set coturn.auth.password="<choose-a-password>" \
   -n digital-twins
 ```
 
 This creates:
-- 1 NIMCache resource (triggers Aero NIM model download)
-- 1 NIMService resource (runs Aero NIM inference after cache is ready)
+- 1 Aero NIM Deployment (AI inference with GPU)
 - 1 Kit Deployment (Omniverse streaming with GPU)
 - 1 Web Deployment (Nginx + React frontend)
-- 1 OpenShift Route (web frontend with edge TLS)
+- 1 coturn Deployment (TURN relay for WebRTC UDP-over-TCP)
+- 3 OpenShift Routes (web edge, Kit signaling edge, coturn passthrough)
 - 1 Custom SCC + RoleBinding (privileged access for Kit and NIM)
 - 2 PVCs (Omniverse cache and local-share)
-- 1 ConfigMap (Nginx config with Kit service discovery)
+- 2 ConfigMaps (Nginx config, stream-config.json)
 
-### 4. Monitor NIM Model Download
+### 5. Configure Stream Config
 
-The NIMCache downloads the DoMINO model from NGC. This can take 10–30 minutes
-depending on network speed.
+After install, get the Route hostnames and update the stream config so the
+web frontend knows how to reach Kit signaling and the TURN relay:
 
 ```bash
-oc get nimcache -n digital-twins -w
+KIT_HOST=$(oc get route rtwt-kit -n digital-twins -o jsonpath='{.spec.host}')
+TURN_HOST=$(oc get route rtwt-turn -n digital-twins -o jsonpath='{.spec.host}')
+TURN_PASS="<same-password-from-step-4>"
+
+helm upgrade rtwt . \
+  -f values.yaml \
+  -f values-openshift.yaml \
+  --set coturn.auth.password="${TURN_PASS}" \
+  --set streamConfig.signalingServer="${KIT_HOST}" \
+  --set streamConfig.turn.urls="turns:${TURN_HOST}:443?transport=tcp" \
+  --set streamConfig.turn.username="turnuser" \
+  --set streamConfig.turn.credential="${TURN_PASS}" \
+  -n digital-twins
 ```
 
-Wait until the cache shows `Ready`:
+### 6. Monitor Startup
 
+The Aero NIM downloads the model on first start (10-30 minutes). Kit compiles
+shaders on first launch (up to 30 minutes; cached in PVC for subsequent starts).
+
+```bash
+# Watch all pods
+oc get pods -n digital-twins -w
+
+# Monitor Aero NIM model download
+oc logs -f deploy/rtwt-aeronim -n digital-twins
+
+# Monitor Kit shader compilation
+oc logs -f deploy/rtwt-kit -n digital-twins
 ```
-NAME             STATUS   AGE
-aeronim-cache    Ready    15m
-```
+
+Wait until all 4 pods show `Running 1/1`.
 
 ## Verification
 
@@ -250,28 +336,35 @@ oc get pods -n digital-twins
 Expected pods:
 
 ```
-NAME                           READY   STATUS    RESTARTS   AGE
-aeronim-0                      1/1     Running   0          5m
-rtwt-kit-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
-rtwt-web-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
+NAME                              READY   STATUS    RESTARTS   AGE
+rtwt-aeronim-xxxxxxxxxx-xxxxx     1/1     Running   0          5m
+rtwt-coturn-xxxxxxxxxx-xxxxx      1/1     Running   0          5m
+rtwt-kit-xxxxxxxxxx-xxxxx         1/1     Running   0          5m
+rtwt-web-xxxxxxxxxx-xxxxx         1/1     Running   0          5m
 ```
 
-### Check NIMService Status
+### Check Routes
 
 ```bash
-oc get nimservice -n digital-twins
+oc get routes -n digital-twins
 ```
+
+Expected routes: `rtwt-web` (edge), `rtwt-kit` (edge), `rtwt-turn` (passthrough).
 
 ### Health Checks
 
 ```bash
 # Aero NIM health
 oc exec deploy/rtwt-kit -n digital-twins -- \
-  curl -s http://aeronim:8080/v1/health/ready
+  curl -s http://rtwt-aeronim:8080/v1/health/ready
 
 # Web frontend
 oc exec deploy/rtwt-web -n digital-twins -- \
   curl -s http://localhost/
+
+# Stream config served correctly
+oc exec deploy/rtwt-web -n digital-twins -- \
+  curl -s http://localhost/stream-config.json
 ```
 
 ## Accessing the UI
@@ -279,31 +372,20 @@ oc exec deploy/rtwt-web -n digital-twins -- \
 ### Web Frontend (via Route)
 
 ```bash
-oc get route rtwt-web -n digital-twins -o jsonpath='{.spec.host}'
+WEB_HOST=$(oc get route rtwt-web -n digital-twins -o jsonpath='{.spec.host}')
+KIT_HOST=$(oc get route rtwt-kit -n digital-twins -o jsonpath='{.spec.host}')
+echo "https://${WEB_HOST}/?server=${KIT_HOST}&width=1920&height=1080&fps=60"
 ```
 
-Open `https://<route-hostname>` in your browser. The React UI loads and
-establishes a WebRTC connection to the Kit streaming service.
+Open that URL in your browser. The React UI loads, fetches `/stream-config.json`
+(which contains the TURN relay details), and establishes a WebRTC connection to
+Kit through the coturn TURN relay.
 
-### Kit WebRTC Streaming (via NodePort)
-
-The Kit service exposes WebRTC streaming ports as NodePorts. Determine the node
-IP and allocated ports:
-
-```bash
-# Get the node where Kit is running
-oc get pod -l app.kubernetes.io/component=kit -n digital-twins \
-  -o jsonpath='{.items[0].status.hostIP}'
-
-# Get the allocated NodePorts
-oc get svc rtwt-kit -n digital-twins
-```
-
-The web frontend must be configured to connect to the Kit streaming endpoint.
-If the WebRTC connection does not establish, verify that:
-1. The Kit NodePort ports are reachable from the client browser
-2. Firewall rules allow UDP traffic on the allocated NodePorts
-3. The Kit pod has GPU access and started successfully
+If the stream does not connect, verify:
+1. All 4 pods are `Running 1/1`
+2. The `streamConfig` values were set correctly (Step 5 above)
+3. The coturn TLS certificate is valid: `oc get certificate rtwt-coturn-tls -n digital-twins`
+4. Check browser console for `[OmniverseAPI] TURN relay injected:` message
 
 ## Testing End-to-End
 
@@ -354,16 +436,27 @@ Operator path, the NIMService handles IPC requirements directly.
 
 ### 3. WebRTC Streaming Cannot Use OpenShift Routes
 
-**What happened:** OpenShift Routes only handle HTTP(S) traffic. Omniverse Kit
-App Streaming uses WebRTC which requires direct UDP connectivity on ports
-47995–48012 and 49000–49007 for the media stream.
+**What happened:** OpenShift Routes only handle HTTP(S) traffic (Layer 7, TCP).
+Omniverse Kit App Streaming uses WebRTC which requires UDP on ports 47995-48012
+and 49000-49007 for the media stream. There is no mechanism in the Route API to
+expose UDP traffic. Inside the cluster everything works fine; the problem is
+purely about getting external browser traffic to Kit's UDP ports.
 
 **Services affected:** Kit (WebRTC streaming to browser)
 
-**Fix:** The Kit service uses `type: NodePort` instead of ClusterIP. The web
-frontend Route handles the HTML/API/WebSocket traffic, while the browser
-connects directly to Kit's NodePorts for the WebRTC media stream. Ensure
-firewall rules allow UDP traffic on the allocated NodePort range.
+**Fix:** Added a coturn TURN relay server that tunnels WebRTC UDP media over
+TLS/TCP. The browser connects to coturn through a passthrough TLS Route, and
+coturn relays the media to Kit's pod over UDP internally within the cluster.
+The client-side JavaScript monkey-patches `RTCPeerConnection` to inject the
+TURN server and force `iceTransportPolicy: "relay"`. Kit uses ClusterIP (not
+NodePort). This approach aligns with NVIDIA's newer Kit App-Streaming (KAS)
+architecture direction.
+
+**Key insight:** The NVIDIA streaming library rewrites ICE candidate IPs using
+the `mediaServer` config parameter. When a TURN relay is configured, the
+`mediaServer` parameter must be omitted so coturn can reach Kit's actual pod IP
+over UDP internally, rather than trying to route through the external Route
+hostname.
 
 ### 4. GPU Scheduling and Tolerations
 
@@ -447,7 +540,18 @@ screen and users may think the deployment failed.
 `oc logs -f deploy/rtwt-kit` to track shader compilation progress. Ensure
 the `ov-cache` PVC persists across pod restarts to avoid re-compilation.
 
-### 9. TOKENIZERS_PARALLELISM Race Condition
+### 9. Aero NIM Shared Memory Too Small
+
+**What happened:** The Aero NIM's Triton inference server requires more than the
+default 64 MB of `/dev/shm` for shared memory. The container crashes with
+`Failed to increase the shared memory pool size`.
+
+**Services affected:** Aero NIM
+
+**Fix:** The Helm chart mounts an `emptyDir` volume at `/dev/shm` with
+`sizeLimit` set via `aeronim.shmSize` (default 2Gi).
+
+### 10. TOKENIZERS_PARALLELISM Race Condition
 
 **What happened:** NIM containers using HuggingFace tokenizers may hit a thread
 pool race condition, causing startup failures.

--- a/web-app/src/OmniverseApi.ts
+++ b/web-app/src/OmniverseApi.ts
@@ -1,5 +1,11 @@
 import { AppStreamer, StreamType } from '@nvidia/omniverse-webrtc-streaming-library';
 
+export interface TurnConfig {
+    urls: string;
+    username: string;
+    credential: string;
+}
+
 export interface OmniverseStreamConfig {
     source: "local",
     videoElementId: string,
@@ -7,7 +13,9 @@ export interface OmniverseStreamConfig {
     messageElementId: string,
     urlLocation: {
         search: string
-    }
+    },
+    turn?: TurnConfig,
+    forceWSS?: boolean,
 }
 
 
@@ -52,14 +60,39 @@ export class OmniverseAPI {
         const signalingPort = Number(params.get("signalingPort") ?? 49100);
         const mediaPortParam = params.get("mediaPort");
         const mediaPort = mediaPortParam != null ? Number(mediaPortParam) : undefined;
+        const forceWSS = config.forceWSS ?? false;
+
+        // When a TURN relay is configured, monkey-patch RTCPeerConnection so
+        // every connection the NVIDIA streaming library creates includes the
+        // relay server. This forces all media through the TURN-TLS tunnel,
+        // bypassing the UDP ingress limitation on OpenShift Routes.
+        if (config.turn?.urls) {
+            const turnServer: RTCIceServer = {
+                urls: config.turn.urls,
+                username: config.turn.username,
+                credential: config.turn.credential,
+            };
+            const NativeRTCPC = window.RTCPeerConnection;
+            const Patched = function (this: RTCPeerConnection, rtcConfig?: RTCConfiguration) {
+                const patched: RTCConfiguration = { ...(rtcConfig || {}) };
+                patched.iceServers = [...(patched.iceServers || []), turnServer];
+                patched.iceTransportPolicy = "relay";
+                return new NativeRTCPC(patched);
+            } as unknown as typeof RTCPeerConnection;
+            Patched.prototype = NativeRTCPC.prototype;
+            Object.setPrototypeOf(Patched, NativeRTCPC);
+            window.RTCPeerConnection = Patched;
+            console.info("[OmniverseAPI] TURN relay injected:", config.turn.urls);
+        }
 
         const streamConfig = {
             videoElementID: config.videoElementId,
             audioElementID: config.audioElementId,
             signalingServer: server,
             signalingPort,
-            mediaServer: server,
+            ...(config.turn?.urls ? {} : { mediaServer: server }),
             ...(mediaPort != null ? { mediaPort } : {}),
+            ...(forceWSS ? { forceWSS: true } : {}),
             auotLaunch: true,
             cursor: 'free' as const,
             mic: false,

--- a/web-app/src/OmniverseApiContext.tsx
+++ b/web-app/src/OmniverseApiContext.tsx
@@ -5,6 +5,7 @@ import {
   OmniverseAPI,
   StreamHandlerCallback,
   OmniverseStreamStatus,
+  TurnConfig,
 } from "./OmniverseApi";
 
 export const defaultVideoElementId = "remote-video";
@@ -22,6 +23,25 @@ const defaultOnStreamCustomEvent = (_message: unknown) => {
   // console.debug(message);
 };
 
+interface StreamServerConfig {
+  signalingServer?: string;
+  signalingPort?: number;
+  forceWSS?: boolean;
+  turn?: TurnConfig | null;
+}
+
+async function fetchStreamConfig(): Promise<StreamServerConfig | null> {
+  try {
+    const resp = await fetch("/stream-config.json");
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    if (!data.signalingServer) return null;
+    return data as StreamServerConfig;
+  } catch {
+    return null;
+  }
+}
+
 function createOmniverseApi(
   videoElementId: string,
   audioElementId: string,
@@ -29,7 +49,8 @@ function createOmniverseApi(
   onStreamStart: StreamHandlerCallback,
   onStreamUpdate: StreamHandlerCallback,
   onStreamCustomEvent: StreamHandlerCallback,
-  onInferenceComplete?: StreamHandlerCallback 
+  onInferenceComplete?: StreamHandlerCallback,
+  serverConfig?: StreamServerConfig | null,
 ): OmniverseAPI {
   const queryParams = new URLSearchParams(window.location.search);
   const queryParamOrDefault = (name: string, defaultVal: unknown) => {
@@ -39,18 +60,32 @@ function createOmniverseApi(
     }
     return queryParams.get(name);
   };
-  const server = queryParamOrDefault("server", window.location.hostname === "localhost" ? "127.0.0.1" : window.location.hostname);
+
+  const defaultServer = window.location.hostname === "localhost" ? "127.0.0.1" : window.location.hostname;
+  const server = serverConfig?.signalingServer
+    ? queryParamOrDefault("server", serverConfig.signalingServer)
+    : queryParamOrDefault("server", defaultServer);
   const width = queryParamOrDefault("width", 1920);
   const height = queryParamOrDefault("height", 1080);
   const fps = queryParamOrDefault("fps", 60);
-  const url = `server=${server}&resolution=${width}:${height}&fps=${fps}&mic=0&cursor=free&autolaunch=true`;
+
+  let url = `server=${server}&resolution=${width}:${height}&fps=${fps}&mic=0&cursor=free&autolaunch=true`;
+  if (serverConfig?.signalingPort) {
+    url += `&signalingPort=${serverConfig.signalingPort}`;
+  }
   console.log(`Omniverse Stream URL: ${url}`);
+
+  const turn = serverConfig?.turn?.urls ? serverConfig.turn as TurnConfig : undefined;
+  const forceWSS = serverConfig?.forceWSS ?? false;
+
   const streamConfig: OmniverseStreamConfig = {
     source: "local",
     videoElementId,
     audioElementId,
     messageElementId,
     urlLocation: { search: url },
+    turn,
+    forceWSS,
   };
   const api = new OmniverseAPI(
     streamConfig,
@@ -59,7 +94,6 @@ function createOmniverseApi(
     onStreamCustomEvent
   );
 
-  // Register 'inference complete' callback
   if (onInferenceComplete) {
     api.onInferenceComplete(onInferenceComplete);
   }
@@ -130,16 +164,23 @@ export const OmniverseApiProvider = ({
       return;
     }
     apiInitialized.current = true;
-    const api = createOmniverseApi(
-      defaultVideoElementId,
-      defaultAudioElementId,
-      defaultMessageElementId,
-      onStreamStart,
-      onStreamUpdate,
-      defaultOnStreamCustomEvent,
-      onInferenceComplete
-    );
-    setApi(api);
+
+    fetchStreamConfig().then((serverConfig) => {
+      if (serverConfig) {
+        console.info("[OmniverseApiProvider] Stream config loaded:", serverConfig);
+      }
+      const api = createOmniverseApi(
+        defaultVideoElementId,
+        defaultAudioElementId,
+        defaultMessageElementId,
+        onStreamStart,
+        onStreamUpdate,
+        defaultOnStreamCustomEvent,
+        onInferenceComplete,
+        serverConfig,
+      );
+      setApi(api);
+    });
   }, [apiInitialized, onStreamStart, onStreamUpdate]);
   return (
     <OmniverseApiContext.Provider value={{ api, status }}>


### PR DESCRIPTION
**Description:**

This PR adds full OpenShift deployment support for the Digital Twins for Fluid Simulation blueprint, validated end-to-end on a Red Hat OpenShift AI cluster. This blueprint had no Helm chart or Kubernetes deployment support -- it was Docker Compose only. I built the Helm chart from scratch by translating the `compose.yml` (3 services: Aero NIM, Omniverse Kit, and the web frontend) into Kubernetes resources -- Deployments, Services, PVCs, ConfigMaps, and Secrets.

**What's included:**

- **`openshift.enabled` flag** in the base chart values (off by default, zero impact on non-OpenShift deployments)

- **`templates/openshift.yaml`** -- conditional template that creates OpenShift Routes (edge TLS for web frontend and Kit signaling, passthrough TLS for coturn), a custom SecurityContextConstraints (Kit requires privileged GPU/Vulkan access), and SCC RoleBindings

- **`templates/aeronim-nim.yaml`** -- NIM Operator template (NIMCache + NIMService) for the DoMINO Automotive Aero NIM, gated by `.Capabilities.APIVersions.Has` so it renders only when the NIM Operator is installed

- **`templates/coturn-deployment.yaml`** -- TURN relay server (coturn) that tunnels WebRTC UDP media over TCP. Kit uses WebRTC for real-time 3D streaming which requires UDP, but OpenShift Routes are HTTP/S only (Layer 7, TCP). The browser connects to coturn through a passthrough TLS Route, and coturn relays media to Kit's pod over UDP internally. This approach aligns with NVIDIA's newer Kit App-Streaming (KAS) direction

- **`templates/stream-config.yaml`** + **`web-app/src/OmniverseApi.ts`** changes -- dynamic TURN configuration delivered to the frontend at runtime via a ConfigMap-backed JSON endpoint; client-side RTCPeerConnection monkey-patching forces all media through the TURN relay. All changes are conditional on TURN config presence, preserving original behavior for non-OpenShift deployments

- **`values-openshift.yaml`** -- overlay file enabling OpenShift features, configuring GPU node tolerations, `/dev/shm` sizing for Triton inference (2Gi), coturn auth and TLS, and stream config for the TURN relay

- **`docs/deploy-openshift.md`** -- full deployment runbook covering prerequisites, Helm install, cert-manager setup for coturn TLS, verification, and documented OpenShift-specific challenges with solutions

**How it works:** Users deploy with a single command:

```bash
helm install rtwt deploy/helm/digital-twins-fluid-sim/ \
  -f deploy/helm/digital-twins-fluid-sim/values.yaml \
  -f deploy/helm/digital-twins-fluid-sim/values-openshift.yaml \
  -n digital-twins
```

**Validated:** Deployed and tested end-to-end on an OpenShift AI cluster -- Aero NIM running inference on 1M-point CFD simulations, Kit streaming the 3D viewport to a browser via WebRTC through the TURN relay, and the full interactive workflow (camera switching, car configuration changes, speed adjustments, multiple visualization modes) accessible from a standard browser with no local GPU required.

---